### PR TITLE
Week6 HW

### DIFF
--- a/config/logmiddleware.py
+++ b/config/logmiddleware.py
@@ -1,0 +1,10 @@
+import logging
+logger = logging.getLogger('django.request')
+
+class RequestLoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        logger.info(f"{request.method} {request.path}")
+        return self.get_response(request)

--- a/config/settings.py
+++ b/config/settings.py
@@ -166,6 +166,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AUTH_USER_MODEL = 'accounts.User'
 
 # log관련 코드 추가
+BASE_DIR = Path(__file__).resolve().parent.parent
 log_directory = os.path.join(BASE_DIR, 'logs') # linux 서버 상에서 django가 run되면 logs라는 디렉토리가 생성
 os.makedirs(log_directory, exist_ok=True)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -40,7 +40,7 @@ SECRET_KEY = get_secret("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -59,13 +59,14 @@ PROJECT_APPS = [
 ]
 
 THIRD_PARTY_APPS = [
-
+    'corsheaders',
 ]
 
 
 INSTALLED_APPS = DJANGO_APPS + PROJECT_APPS + THIRD_PARTY_APPS
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware', # 반드시 가장 위쪽에 추가
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -73,6 +74,19 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+# 인증 관련 요청(쿠키, 세션 등)을 허용
+# 예를 들어 브라우저가 백엔드 서버로 쿠키를 전송하거나, 백엔드에서 쿠키를 응답으로 보낼 수 있음
+CORS_ALLOW_CREDENTIALS = True
+
+# 서버로 요청 보낼 수 있는 도메인들 정의
+# 여기에서의 localhost는 EC2 인스턴스의 로컬환경이 아니라 프론트엔드 개발 로컬 환경 의미
+# 3000 포트는 프론트엔드 React 애플리케이션의 포트 번호
+# 추후 프론트엔드에서 웹 페이지 배포 후 도메인 매핑했다면 해당 도메인 추가 필요
+CORS_ALLOWED_ORIGINS = [ 
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
 ]
 
 ROOT_URLCONF = 'config.urls'

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,6 +37,22 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.7.0"
+description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_cors_headers-4.7.0-py3-none-any.whl", hash = "sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070"},
+    {file = "django_cors_headers-4.7.0.tar.gz", hash = "sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b"},
+]
+
+[package.dependencies]
+asgiref = ">=3.6"
+django = ">=4.2"
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 description = "A non-validating SQL parser."
@@ -68,4 +84,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "4a0b882f3c9e66118d03cade1f7382fdaa86736e3069c01c3baa41b15bc73371"
+content-hash = "033975729e8f7e03ae35727f7f3dbbbf1e37e0c542ad9c52988726c581253dc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "django (>=5.1.7,<6.0.0)"
+    "django (>=5.1.7,<6.0.0)",
+    "django-cors-headers (>=4.7.0,<5.0.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION

![터미널_로그_체크](https://github.com/user-attachments/assets/543b61c1-ba8c-427d-b775-0df27060e127)

위의 경우 background에서 server가 돌아갈 때 terminal에서 직접 cat을 통해 log를 확인한 것이다. 이런 경우 server가 갑자기 다운되었을 때의 log 기록이 모두 날아간다. 따라서 log관련 Base_dir을 manage.py와 동일한 위치에 만들어주었다.

아래는 서버가 다운되었다는 가정을 한 상태로 보는 것이다.

![오프라인_로그_체크](https://github.com/user-attachments/assets/33f933f4-8a1f-4ad8-8de6-21c3373f6004)

kill을 통해 background를 확실하게 다운시켰다. 만약 log 파일이 따로 존재하지 않는다면 이전의 log 기록들은 소멸되었을 것이다.
하지만 동일하게 offline 상태에서 log를 찍으면 online일 때의 모든 log 기록을 조회할 수 있는 것을 알 수 있다.